### PR TITLE
Version bump

### DIFF
--- a/bump_version.py
+++ b/bump_version.py
@@ -1,0 +1,93 @@
+# Copyright 2019 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""\
+Bump chart version.
+"""
+
+import argparse
+import io
+import os
+import yaml
+
+Loader = getattr(yaml, "CLoader", "Loader")
+Dumper = getattr(yaml, "CDumper", "Dumper")
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+REQ_DIR = os.path.join(THIS_DIR, "charts", "hdfs-k8s")
+REQ_FN = os.path.join(REQ_DIR, "requirements.yaml")
+
+
+def csv(arg):
+    return {_.strip() for _ in arg.split(",")}
+
+
+def dump(doc, f):
+    yaml.dump(doc, f, Dumper, default_flow_style=False)
+
+
+def get_charts_to_bump(all_charts, args):
+    unknown = (args.include | args.exclude) - all_charts
+    if unknown:
+        raise RuntimeError(f"unknown chart(s): {','.join(unknown)}")
+    return args.include if args.include else all_charts - args.exclude
+
+
+def confirm(charts, to_bump):
+    w = max(len(_) for _ in charts)
+    print(f"{'CHART'.ljust(w)} BUMP")
+    for c in sorted(charts):
+        print(f"{c.ljust(w)} {'Y' if c in to_bump else 'N'}")
+    return input("  Is this OK (y/n)? ").lower().startswith("y")
+
+
+def bump_chart(fn, version):
+    with io.open(fn, "rt") as f:
+        doc = yaml.load(f, Loader)
+    doc["version"] = version
+    with io.open(fn, "wt") as f:
+        dump(doc, f)
+
+
+def main(args):
+    with io.open(REQ_FN, "rt") as f:
+        doc = yaml.load(f, Loader)
+    root = doc["dependencies"]
+    charts = {_["name"] for _ in root if _["repository"].startswith("file")}
+    to_bump = get_charts_to_bump(charts, args)
+    if args.force or confirm(charts, to_bump):
+        for dep in root:
+            if dep["name"] not in to_bump:
+                continue
+            dep["version"] = args.version
+            d = dep["repository"].split(":", 1)[-1].strip("/")
+            fn = os.path.join(REQ_DIR, d, "Chart.yaml")
+            bump_chart(fn, args.version)
+        with io.open(REQ_FN, "wt") as f:
+            dump(doc, f)
+        bump_chart(os.path.join(REQ_DIR, "Chart.yaml"), args.version)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", metavar="VERSION",
+                        help="new version tag")
+    parser.add_argument("-f", "--force", action="store_true",
+                        help="don't ask for confirmation")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("-i", "--include", metavar="c1,c2,...", type=csv,
+                       default=set(), help="include only these charts")
+    group.add_argument("-e", "--exclude", metavar="c1,c2,...", type=csv,
+                       default=set(), help="include all charts except these")
+    main(parser.parse_args())

--- a/charts/hdfs-client-k8s/Chart.yaml
+++ b/charts/hdfs-client-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A client for HDFS on Kubernetes.
 name: hdfs-client-k8s
-version: 0.1.0
+version: 0.2.0

--- a/charts/hdfs-client-k8s/Chart.yaml
+++ b/charts/hdfs-client-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
+description: A client for HDFS on Kubernetes.
 name: hdfs-client-k8s
 version: 0.1.0
-description: A client for HDFS on Kubernetes.

--- a/charts/hdfs-config-k8s/Chart.yaml
+++ b/charts/hdfs-config-k8s/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: '1.0'
 description: A Helm chart for configuring HDFS on Kubernetes
 name: hdfs-config-k8s
 version: 0.1.0

--- a/charts/hdfs-config-k8s/Chart.yaml
+++ b/charts/hdfs-config-k8s/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for configuring HDFS on Kubernetes
 name: hdfs-config-k8s
-version: 0.1.0
+version: 0.2.0

--- a/charts/hdfs-config-k8s/Chart.yaml
+++ b/charts/hdfs-config-k8s/Chart.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
-appVersion: '1.0'
 description: A Helm chart for configuring HDFS on Kubernetes
 name: hdfs-config-k8s
 version: 0.2.0

--- a/charts/hdfs-datanode-k8s/Chart.yaml
+++ b/charts/hdfs-datanode-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Datanodes for HDFS on Kubernetes.
 name: hdfs-datanode-k8s
-version: 0.1.0
+version: 0.2.0

--- a/charts/hdfs-datanode-k8s/Chart.yaml
+++ b/charts/hdfs-datanode-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
+description: Datanodes for HDFS on Kubernetes.
 name: hdfs-datanode-k8s
 version: 0.1.0
-description: Datanodes for HDFS on Kubernetes.

--- a/charts/hdfs-journalnode-k8s/Chart.yaml
+++ b/charts/hdfs-journalnode-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Journalnode quorum used by HDFS on Kubernetes.
 name: hdfs-journalnode-k8s
-version: 0.1.0
+version: 0.2.0

--- a/charts/hdfs-journalnode-k8s/Chart.yaml
+++ b/charts/hdfs-journalnode-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
+description: Journalnode quorum used by HDFS on Kubernetes.
 name: hdfs-journalnode-k8s
 version: 0.1.0
-description: Journalnode quorum used by HDFS on Kubernetes.

--- a/charts/hdfs-k8s/Chart.yaml
+++ b/charts/hdfs-k8s/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: '1.0'
 description: An entry-point Helm chart for launching HDFS on Kubernetes
 name: hdfs
 version: 0.1.0

--- a/charts/hdfs-k8s/Chart.yaml
+++ b/charts/hdfs-k8s/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: An entry-point Helm chart for launching HDFS on Kubernetes
 name: hdfs
-version: 0.1.0
+version: 0.2.0

--- a/charts/hdfs-k8s/Chart.yaml
+++ b/charts/hdfs-k8s/Chart.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
-appVersion: '1.0'
 description: An entry-point Helm chart for launching HDFS on Kubernetes
 name: hdfs
 version: 0.2.0

--- a/charts/hdfs-k8s/requirements.yaml
+++ b/charts/hdfs-k8s/requirements.yaml
@@ -13,7 +13,7 @@ dependencies:
   - ha
   - kerberos
   - simple
-  version: 0.1.0
+  version: 0.2.0
 - condition: condition.subchart.kerberos
   name: hdfs-krb5-k8s
   repository: file://../hdfs-krb5-k8s
@@ -26,20 +26,20 @@ dependencies:
   tags:
   - ha
   - kerberos
-  version: 0.1.0
+  version: 0.2.0
 - condition: condition.subchart.namenode
   name: hdfs-namenode-k8s
   repository: file://../hdfs-namenode-k8s
   tags:
   - ha
   - kerberos
-  version: 0.1.0
+  version: 0.2.0
 - condition: condition.subchart.simple-namenode
   name: hdfs-simple-namenode-k8s
   repository: file://../hdfs-simple-namenode-k8s
   tags:
   - simple
-  version: 0.1.0
+  version: 0.2.0
 - condition: condition.subchart.datanode
   name: hdfs-datanode-k8s
   repository: file://../hdfs-datanode-k8s
@@ -47,7 +47,7 @@ dependencies:
   - ha
   - kerberos
   - simple
-  version: 0.1.0
+  version: 0.2.0
 - condition: condition.subchart.client
   name: hdfs-client-k8s
   repository: file://../hdfs-client-k8s
@@ -55,4 +55,4 @@ dependencies:
   - ha
   - kerberos
   - simple
-  version: 0.1.0
+  version: 0.2.0

--- a/charts/hdfs-k8s/requirements.yaml
+++ b/charts/hdfs-k8s/requirements.yaml
@@ -19,7 +19,7 @@ dependencies:
   repository: file://../hdfs-krb5-k8s
   tags:
   - kerberos
-  version: 0.1.0
+  version: 0.2.0
 - condition: condition.subchart.journalnode
   name: hdfs-journalnode-k8s
   repository: file://../hdfs-journalnode-k8s

--- a/charts/hdfs-k8s/requirements.yaml
+++ b/charts/hdfs-k8s/requirements.yaml
@@ -1,59 +1,58 @@
 dependencies:
-  - name: zookeeper
-    version: "1.0.0"
-    repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-    condition: condition.subchart.zookeeper
-    tags:
-      - ha
-      - kerberos
-  - name: hdfs-config-k8s
-    version: "0.1.0"
-    repository: "file://../hdfs-config-k8s"
-    condition: condition.subchart.config
-    tags:
-      - ha
-      - kerberos
-      - simple
-  - name: hdfs-krb5-k8s
-    version: "0.1.0"
-    repository: "file://../hdfs-krb5-k8s"
-    condition: condition.subchart.kerberos
-    tags:
-      - kerberos
-  - name: hdfs-journalnode-k8s
-    version: "0.1.0"
-    repository: "file://../hdfs-journalnode-k8s"
-    condition: condition.subchart.journalnode
-    tags:
-      - ha
-      - kerberos
-  - name: hdfs-namenode-k8s
-    version: "0.1.0"
-    repository: "file://../hdfs-namenode-k8s"
-    condition: condition.subchart.namenode
-    tags:
-      - ha
-      - kerberos
-  # Non-HA namenode. Disabled by default
-  - name: hdfs-simple-namenode-k8s
-    version: "0.1.0"
-    repository: "file://../hdfs-simple-namenode-k8s"
-    condition: condition.subchart.simple-namenode
-    tags:
-      - simple
-  - name: hdfs-datanode-k8s
-    version: "0.1.0"
-    repository: "file://../hdfs-datanode-k8s"
-    condition: condition.subchart.datanode
-    tags:
-      - ha
-      - kerberos
-      - simple
-  - name: hdfs-client-k8s
-    version: "0.1.0"
-    repository: "file://../hdfs-client-k8s"
-    condition: condition.subchart.client
-    tags:
-      - ha
-      - kerberos
-      - simple
+- condition: condition.subchart.zookeeper
+  name: zookeeper
+  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  tags:
+  - ha
+  - kerberos
+  version: 1.0.0
+- condition: condition.subchart.config
+  name: hdfs-config-k8s
+  repository: file://../hdfs-config-k8s
+  tags:
+  - ha
+  - kerberos
+  - simple
+  version: 0.1.0
+- condition: condition.subchart.kerberos
+  name: hdfs-krb5-k8s
+  repository: file://../hdfs-krb5-k8s
+  tags:
+  - kerberos
+  version: 0.1.0
+- condition: condition.subchart.journalnode
+  name: hdfs-journalnode-k8s
+  repository: file://../hdfs-journalnode-k8s
+  tags:
+  - ha
+  - kerberos
+  version: 0.1.0
+- condition: condition.subchart.namenode
+  name: hdfs-namenode-k8s
+  repository: file://../hdfs-namenode-k8s
+  tags:
+  - ha
+  - kerberos
+  version: 0.1.0
+- condition: condition.subchart.simple-namenode
+  name: hdfs-simple-namenode-k8s
+  repository: file://../hdfs-simple-namenode-k8s
+  tags:
+  - simple
+  version: 0.1.0
+- condition: condition.subchart.datanode
+  name: hdfs-datanode-k8s
+  repository: file://../hdfs-datanode-k8s
+  tags:
+  - ha
+  - kerberos
+  - simple
+  version: 0.1.0
+- condition: condition.subchart.client
+  name: hdfs-client-k8s
+  repository: file://../hdfs-client-k8s
+  tags:
+  - ha
+  - kerberos
+  - simple
+  version: 0.1.0

--- a/charts/hdfs-krb5-k8s/Chart.yaml
+++ b/charts/hdfs-krb5-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Kerberos server that can be used for HDFS on Kubernetes.
 name: hdfs-krb5-k8s
-version: 0.1.0
+version: 0.2.0

--- a/charts/hdfs-krb5-k8s/Chart.yaml
+++ b/charts/hdfs-krb5-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
+description: Kerberos server that can be used for HDFS on Kubernetes.
 name: hdfs-krb5-k8s
 version: 0.1.0
-description: Kerberos server that can be used for HDFS on Kubernetes.

--- a/charts/hdfs-namenode-k8s/Chart.yaml
+++ b/charts/hdfs-namenode-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
+description: namenodes in HDFS on Kubernetes.
 name: hdfs-namenode-k8s
 version: 0.1.0
-description: namenodes in HDFS on Kubernetes.

--- a/charts/hdfs-namenode-k8s/Chart.yaml
+++ b/charts/hdfs-namenode-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: namenodes in HDFS on Kubernetes.
 name: hdfs-namenode-k8s
-version: 0.1.0
+version: 0.2.0

--- a/charts/hdfs-simple-namenode-k8s/Chart.yaml
+++ b/charts/hdfs-simple-namenode-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Non-HA namenode for HDFS on Kubernetes.
 name: hdfs-simple-namenode-k8s
-version: 0.1.0
+version: 0.2.0

--- a/charts/hdfs-simple-namenode-k8s/Chart.yaml
+++ b/charts/hdfs-simple-namenode-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
+description: Non-HA namenode for HDFS on Kubernetes.
 name: hdfs-simple-namenode-k8s
 version: 0.1.0
-description: Non-HA namenode for HDFS on Kubernetes.


### PR DESCRIPTION
Bumps the version tag to 0.2.0 for all charts except `hdfs-krb5-k8s` (which hasn't changed). Diff best viewed commit-by-commit due to the prettifying step.