### PR TITLE
Fix datanode liveness probe

### DIFF
--- a/charts/hdfs-datanode-k8s/templates/datanode-daemonset.yaml
+++ b/charts/hdfs-datanode-k8s/templates/datanode-daemonset.yaml
@@ -1,37 +1,3 @@
-# Provides datanode helper scripts.
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ template "hdfs-k8s.datanode.fullname" . }}-scripts
-  labels:
-    app: {{ template "hdfs-k8s.datanode.name" . }}
-    chart: {{ template "hdfs-k8s.subchart" . }}
-    release: {{ .Release.Name }}
-data:
-  check-status.sh: |
-    #!/usr/bin/env bash
-    # Exit on error. Append "|| true" if you expect an error.
-    set -o errexit
-    # Exit on error inside any functions or subshells.
-    set -o errtrace
-    # Do not allow use of undefined vars. Use ${VAR:-} to use an undefined VAR
-    set -o nounset
-    # Catch an error in command pipes. e.g. mysqldump fails (but gzip succeeds)
-    # in `mysqldump |gzip`
-    set -o pipefail
-    # Turn on traces, useful while debugging.
-    set -o xtrace
-
-    # Check if datanode registered with the namenode and got non-null cluster ID.
-    _PORTS="{{ .Values.httpPort }} {{ .Values.global.dataNodeSecureHttpPort }}"
-    _URL_PATH="jmx?qry=Hadoop:service=DataNode,name=DataNodeInfo"
-    _CLUSTER_ID=""
-    for _PORT in $_PORTS; do
-      _CLUSTER_ID+=$(curl -s http://localhost:${_PORT}/$_URL_PATH |  \
-          grep ClusterId) || true
-    done
-    echo $_CLUSTER_ID | grep -q -v null
----
 # Deleting a daemonset may need some trick. See
 # https://github.com/kubernetes/kubernetes/issues/33245#issuecomment-261250489
 apiVersion: extensions/v1beta1
@@ -98,21 +64,18 @@ spec:
           livenessProbe:
             exec:
               command:
-                - /dn-scripts/check-status.sh
+                - datanode_cid
             initialDelaySeconds: 60
             periodSeconds: 30
           readinessProbe:
             exec:
               command:
-                - /dn-scripts/check-status.sh
+                - datanode_cid
             initialDelaySeconds: 60
             periodSeconds: 30
           securityContext:
             privileged: true
           volumeMounts:
-            - name: dn-scripts
-              mountPath: /dn-scripts
-              readOnly: true
             - name: hdfs-config
               mountPath: /etc/hadoop-custom-conf
               readOnly: true
@@ -149,10 +112,6 @@ spec:
       {{- end }}
       restartPolicy: Always
       volumes:
-        - name: dn-scripts
-          configMap:
-            name: {{ template "hdfs-k8s.datanode.fullname" . }}-scripts
-            defaultMode: 0744
         {{- range $index, $path := .Values.global.dataNodeHostPath }}
         - name: hdfs-data-{{ $index }}
           hostPath:


### PR DESCRIPTION
Fixes #4.
Fixes #6.

Uses the new `datanode_cid` command introduced in crs4/hadoop-docker#15 as the liveness probe.