### PR TITLE
Fix chart name

### DIFF
--- a/charts/hdfs-k8s/Chart.yaml
+++ b/charts/hdfs-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: An entry-point Helm chart for launching HDFS on Kubernetes
-name: hdfs
+name: hdfs-k8s
 version: 0.2.0


### PR DESCRIPTION
Fixes #5.

Sets the top-level chart name to be equal to the dir name, as required by `helm package`