### PR TITLE
Feature/nodeport svc

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -275,6 +275,38 @@ JournalNodes:
       --set global.namenodeHAEnabled=false
 ```
 
+### Allowing access from outside the Kubernetes cluster
+
+This is currently only supported with simple (non-HA) configurations.
+
+Set properties in `hdfsSite` to configure data nodes to use ports appropriate
+for your cloud security group/firewall configuration.
+
+```
+    hdfs-config-k8s:
+      customHadoopConfig:
+         hdfsSite:
+           dfs.datanode.ipc.address: "0.0.0.0:32997"
+           dfs.datanode.address: "0.0.0.0:32998"
+           dfs.datanode.http.address: "0.0.0.0:32999"
+```
+
+Configure ports for NodePort services to expose for namenode:
+
+```
+  global:
+    externalNameNodeHttpPort: 30987
+    externalNameNodePort: 30820
+```
+
+Finally, enabled the node port service in the hdfs-simple-namenode-k8s chart:
+
+```
+    hdfs-simple-namenode-k8s:
+      nodePortSvc:
+        enabled: true
+```
+
 # Security
 
 ## K8s secret containing Kerberos keytab files

--- a/charts/hdfs-client-k8s/Chart.yaml
+++ b/charts/hdfs-client-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A client for HDFS on Kubernetes.
 name: hdfs-client-k8s
-version: 0.3.1
+version: 0.4.0

--- a/charts/hdfs-config-k8s/Chart.yaml
+++ b/charts/hdfs-config-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for configuring HDFS on Kubernetes
 name: hdfs-config-k8s
-version: 0.3.1
+version: 0.4.0

--- a/charts/hdfs-datanode-k8s/Chart.yaml
+++ b/charts/hdfs-datanode-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Datanodes for HDFS on Kubernetes.
 name: hdfs-datanode-k8s
-version: 0.3.1
+version: 0.4.0

--- a/charts/hdfs-journalnode-k8s/Chart.yaml
+++ b/charts/hdfs-journalnode-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Journalnode quorum used by HDFS on Kubernetes.
 name: hdfs-journalnode-k8s
-version: 0.3.1
+version: 0.4.0

--- a/charts/hdfs-k8s/Chart.yaml
+++ b/charts/hdfs-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: An entry-point Helm chart for launching HDFS on Kubernetes
 name: hdfs-k8s
-version: 0.3.1
+version: 0.4.0

--- a/charts/hdfs-k8s/requirements.yaml
+++ b/charts/hdfs-k8s/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
   tags:
   - ha
   - kerberos
-  version: 1.0.0
+  version: 1.3.1
 - condition: condition.subchart.config
   name: hdfs-config-k8s
   repository: file://../hdfs-config-k8s

--- a/charts/hdfs-k8s/requirements.yaml
+++ b/charts/hdfs-k8s/requirements.yaml
@@ -39,7 +39,7 @@ dependencies:
   repository: file://../hdfs-simple-namenode-k8s
   tags:
   - simple
-  version: 0.3.1
+  version: 0.4.0
 - condition: condition.subchart.datanode
   name: hdfs-datanode-k8s
   repository: file://../hdfs-datanode-k8s

--- a/charts/hdfs-k8s/requirements.yaml
+++ b/charts/hdfs-k8s/requirements.yaml
@@ -39,7 +39,7 @@ dependencies:
   repository: file://../hdfs-simple-namenode-k8s
   tags:
   - simple
-  version: 0.4.0
+  version: 0.3.1
 - condition: condition.subchart.datanode
   name: hdfs-datanode-k8s
   repository: file://../hdfs-datanode-k8s

--- a/charts/hdfs-k8s/requirements.yaml
+++ b/charts/hdfs-k8s/requirements.yaml
@@ -13,33 +13,33 @@ dependencies:
   - ha
   - kerberos
   - simple
-  version: 0.3.1
+  version: 0.4.0
 - condition: condition.subchart.kerberos
   name: hdfs-krb5-k8s
   repository: file://../hdfs-krb5-k8s
   tags:
   - kerberos
-  version: 0.3.1
+  version: 0.4.0
 - condition: condition.subchart.journalnode
   name: hdfs-journalnode-k8s
   repository: file://../hdfs-journalnode-k8s
   tags:
   - ha
   - kerberos
-  version: 0.3.1
+  version: 0.4.0
 - condition: condition.subchart.namenode
   name: hdfs-namenode-k8s
   repository: file://../hdfs-namenode-k8s
   tags:
   - ha
   - kerberos
-  version: 0.3.1
+  version: 0.4.0
 - condition: condition.subchart.simple-namenode
   name: hdfs-simple-namenode-k8s
   repository: file://../hdfs-simple-namenode-k8s
   tags:
   - simple
-  version: 0.3.1
+  version: 0.4.0
 - condition: condition.subchart.datanode
   name: hdfs-datanode-k8s
   repository: file://../hdfs-datanode-k8s
@@ -47,7 +47,7 @@ dependencies:
   - ha
   - kerberos
   - simple
-  version: 0.3.1
+  version: 0.4.0
 - condition: condition.subchart.client
   name: hdfs-client-k8s
   repository: file://../hdfs-client-k8s
@@ -55,4 +55,4 @@ dependencies:
   - ha
   - kerberos
   - simple
-  version: 0.3.1
+  version: 0.4.0

--- a/charts/hdfs-k8s/values.yaml
+++ b/charts/hdfs-k8s/values.yaml
@@ -124,6 +124,9 @@ hdfs-simple-namenode-k8s:
   image:
     pullPolicy: IfNotPresent
 
+  nodePortSvc:
+    enabled: false
+
   persistence:    
     ## Namenode data can be stored on a Persistent Volume (as default) or 
     ## on a directory of a cluster node as a k8s HostPath volume.
@@ -243,8 +246,14 @@ global:
   ## NameNode RPC port. See https://issues.apache.org/jira/browse/HDFS-12990
   nameNodePort: 8020
 
+  ## port for namenode's NodePort service
+  externalNameNodePort: ~
+
   ## Namenode web UI port. Default: 9870 for Hadoop 3, 50070 for Hadoop 2.
   nameNodeHttpPort: 9870
+
+  ## port for namenode's web interface NodePort service
+  externalNameNodeHttpPort: ~
 
   ## Parameters for determining which Unix user and group IDs to use in pods.
   ## Persistent volume permission may need to match these.

--- a/charts/hdfs-krb5-k8s/Chart.yaml
+++ b/charts/hdfs-krb5-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Kerberos server that can be used for HDFS on Kubernetes.
 name: hdfs-krb5-k8s
-version: 0.3.1
+version: 0.4.0

--- a/charts/hdfs-namenode-k8s/Chart.yaml
+++ b/charts/hdfs-namenode-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: namenodes in HDFS on Kubernetes.
 name: hdfs-namenode-k8s
-version: 0.3.1
+version: 0.4.0

--- a/charts/hdfs-simple-namenode-k8s/Chart.yaml
+++ b/charts/hdfs-simple-namenode-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Non-HA namenode for HDFS on Kubernetes.
 name: hdfs-simple-namenode-k8s
-version: 0.4.0
+version: 0.3.1

--- a/charts/hdfs-simple-namenode-k8s/Chart.yaml
+++ b/charts/hdfs-simple-namenode-k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Non-HA namenode for HDFS on Kubernetes.
 name: hdfs-simple-namenode-k8s
-version: 0.3.1
+version: 0.4.0

--- a/charts/hdfs-simple-namenode-k8s/templates/namenode-statefulset.yaml
+++ b/charts/hdfs-simple-namenode-k8s/templates/namenode-statefulset.yaml
@@ -1,21 +1,3 @@
-# A headless service to create DNS records.
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ template "hdfs-k8s.namenode.fullname" . }}
-  labels:
-    app: {{ template "hdfs-k8s.namenode.name" . }}
-    chart: {{ template "hdfs-k8s.subchart" . }}
-    release: {{ .Release.Name }}
-spec:
-  ports:
-  - port: {{ .Values.global.nameNodePort }}
-    name: fs
-  clusterIP: None
-  selector:
-    app: {{ template "hdfs-k8s.namenode.name" . }}
-    release: {{ .Release.Name }}
----
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:

--- a/charts/hdfs-simple-namenode-k8s/templates/namenode-svc.yaml
+++ b/charts/hdfs-simple-namenode-k8s/templates/namenode-svc.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "hdfs-k8s.namenode.fullname" . }}
+  labels:
+    app: {{ template "hdfs-k8s.namenode.name" . }}
+    chart: {{ template "hdfs-k8s.subchart" . }}
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    app: {{ template "hdfs-k8s.namenode.name" . }}
+    release: {{ .Release.Name }}
+  clusterIP: None
+  ports:
+  - port: {{ .Values.global.nameNodePort }}
+    name: fs
+  - port: {{ .Values.global.nameNodeHttpPort }}
+    name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ext-{{ template "hdfs-k8s.namenode.fullname" . }}
+  labels:
+    app: {{ template "hdfs-k8s.namenode.name" . }}
+    chart: {{ template "hdfs-k8s.subchart" . }}
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    app: {{ template "hdfs-k8s.namenode.name" . }}
+    release: {{ .Release.Name }}
+  type: NodePort
+  ports:
+  - name: fs
+    port: {{ .Values.global.nameNodePort }}
+    nodePort: {{ .Values.global.externalNameNodePort }} 
+  - name: http
+    port: {{ .Values.global.nameNodeHttpPort }}
+    nodePort: {{ .Values.global.externalNameNodeHttpPort }}


### PR DESCRIPTION
Adds NodePort service for simple namenode configuration and documents how to create an HDFS deployment that is accessible from outside the Kubernetes cluster.